### PR TITLE
ci: bump to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ defaults:
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
 
     steps:
@@ -59,7 +59,7 @@ jobs:
           shfmt -l -d -i 4 **/*.sh
 
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     needs:
       - lint

--- a/.github/workflows/deps-automerge.yml
+++ b/.github/workflows/deps-automerge.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   automerge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'loozhengyuan' }}
 


### PR DESCRIPTION
This commit updates the repositories to use `ubuntu-24.04` runner type.

Idempotency-Key: b65e24792f1426145cd7e87ec4b34af8f1f8997b122f0173c1f5dc88a97e9c97
