### PR TITLE
ci: pin actions by commit hash


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6.0.0
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
 
       - name: Install dependencies
         run: |
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0 # NOTE: Required to fetch ALL tags
 

--- a/.github/workflows/deps-automerge.yml
+++ b/.github/workflows/deps-automerge.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Fetch Dependabot metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
This commit updates the various actions to pin by hash instead of tag.

Pinning by hash is widely considered to be best practice. Considering
that Dependabot now has the ability to bump actions by hash[1], it makes
sense to switch to pinning by hash.

[1]: https://github.com/dependabot/dependabot-core/issues/4691
